### PR TITLE
bug(cloudflare): Fix infinite loop on CloudFlare zones with no records

### DIFF
--- a/cinq_collector_dns/__init__.py
+++ b/cinq_collector_dns/__init__.py
@@ -341,7 +341,7 @@ class DNSCollector(BaseCollector):
             info = response['result_info']
 
             # Check if we have received all records, and if not iterate over the result set
-            if 'total_pages' not in info or page == info['total_pages']:
+            if 'total_pages' not in info or page >= info['total_pages']:
                 done = True
             else:
                 page += 1


### PR DESCRIPTION
When fetching records from CloudFlare's API, they include a `result_info` datastructure with each requests looking like:
```
{
    "page": 1,
    "per_page": 100,
    "total_pages": 1,
    "count": 17,
    "total_count": 17
}
```
The code used to check if the `page` (the number of the current page read) was the same as the `total_pages` argument, it meant that we had read all the pages. However, if a zone has no records, instead of returning a `page` value of 1, it returns `0`, this never triggering the end of collection.

Fixes https://github.com/RiotGames/cloud-inquisitor/issues/153